### PR TITLE
support self closing tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ function parse(xml) {
     }
 
     // self closing tag
-    if (match(/^\s*\/>/)) {
+    if (match(/^\s*\/>\s*/)) {
       return node;
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -151,7 +151,7 @@ it('should support self-closing tags', function () {
 })
 
 it('should support self-closing tags without attributes', function () {
-  var node = parse('<a><b>foo</b><b /><b>bar</b></a>');
+  var node = parse('<a><b>foo</b><b /> <b>bar</b></a>');
   node.root.should.eql({
     "name": "a",
     "attributes": {},


### PR DESCRIPTION
support self closing tags like

`<tag attr=“moo” />`

or 

`<tag />`
