### PR TITLE
Fix blank strings test

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ var should = require('should');
 
 it('should support blank strings', function(){
   var node = parse('');
-  node.should.eql({ declaration: null, root: null });
+  node.should.eql({ declaration: undefined, root: undefined });
 })
 
 it('should support declarations', function(){
@@ -231,7 +231,7 @@ it('should support tags with a dot', function () {
       }],
       content: ""
     })
-})
+});
 
 it('should support tags with hyphen', function () {
   var node = parse(


### PR DESCRIPTION
```
$ make test

  
  ․

  0 passing (9ms)
  1 failing

  1)  should support blank strings:

      AssertionError: expected { declaration: undefined, root: undefined } to equal { declaration: null, root: null } (at declaration, A has undefined and B has null)
      + expected - actual

      +{
      +  "declaration": null
      +  "root": null
      +}
      -{}
      
      at Assertion.fail (/home/kostya/proj/xml-parser/node_modules/should/lib/assertion.js:113:17)
      at Assertion.prop.(anonymous function) [as eql] (/home/kostya/proj/xml-parser/node_modules/should/lib/assertion.js:39:14)
      at Context.<anonymous> (/home/kostya/proj/xml-parser/test/index.js:7:15)
      at callFn (/home/kostya/proj/xml-parser/node_modules/mocha/lib/runnable.js:250:21)
      at Test.Runnable.run (/home/kostya/proj/xml-parser/node_modules/mocha/lib/runnable.js:243:7)
      at Runner.runTest (/home/kostya/proj/xml-parser/node_modules/mocha/lib/runner.js:373:10)
      at /home/kostya/proj/xml-parser/node_modules/mocha/lib/runner.js:451:12
      at next (/home/kostya/proj/xml-parser/node_modules/mocha/lib/runner.js:298:14)
      at /home/kostya/proj/xml-parser/node_modules/mocha/lib/runner.js:308:7
      at next (/home/kostya/proj/xml-parser/node_modules/mocha/lib/runner.js:246:23)
      at Immediate._onImmediate (/home/kostya/proj/xml-parser/node_modules/mocha/lib/runner.js:275:5)
      at processImmediate [as _immediateCallback] (timers.js:358:17)



Makefile:3: recipe for target 'test' failed
make: *** [test] Error 1
```