### PR TITLE
fix empty string test

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ var should = require('should');
 
 it('should support blank strings', function(){
   var node = parse('');
-  node.should.eql({ declaration: null, root: null });
+  node.should.eql({ declaration: undefined, root: undefined });
 })
 
 it('should support declarations', function(){


### PR DESCRIPTION
Right now, the test fails. I'm not sure whether the parser should return `undefined` or `null`, so I modified the test to preserve compatibility.