### PR TITLE
fix dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "debug": "~0.7.4"
   },
   "devDependencies": {
-    "mocha": "*",
-    "should": "*",
-    "matcha": "~0.4.1"
+    "matcha": "^0.6.0",
+    "mocha": "^2.2.5",
+    "should": "^6.0.3"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Using `*` for deps is a bad idea, so I pinned them to their `@latest`. Also, they are now ordered alphabetically.