### PR TITLE
Added test + fix for XML stylesheet declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function parse(xml) {
       node.attributes[attr.name] = attr.value;
     }
 
-    match(/\?>\s*(<\?.*\?>)\s*/);
+    match(/\?>\s*<\?.*?\?>/);
 
     return node;
   }

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function parse(xml) {
       node.attributes[attr.name] = attr.value;
     }
 
-    match(/\?>\s*(<\?.*?>)\s*/);
+    match(/\?>\s*(<\?.*\?>)\s*/);
 
     return node;
   }

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function parse(xml) {
       node.attributes[attr.name] = attr.value;
     }
 
-    match(/\?>\s*/);
+    match(/\?>\s*(<\?.*?>)\s*/);
 
     return node;
   }

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,11 @@ it('should support declarations', function(){
   })
 })
 
+it('should ignore stylesheet declarations', function(){
+  var node = parse('<?xml version="1.0" ?><?xml-stylesheet title="XSL_formatting"?><foo></foo><?xml version="1.0" ?>');
+  should.exist(node.root);
+})
+
 it('should support comments', function(){
   var node = parse('<!-- hello --><foo></foo><!-- world -->');
   node.root.should.eql({


### PR DESCRIPTION
Currently this parsing fails when it encounters an xml feed which has an `xml-stylesheet` tag like the following:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-stylesheet title="XSL_formatting" type="text/xsl" href="/shared/bsp/xsl/rss/nolsol.xsl"?>
```

[The BBC news rss feed](http://feeds.bbci.co.uk/news/uk/rss.xml) is an example.

I've written a test which fails without the changes, and implemented a fix that basically removes any content enclosed by `<? ?>` that immediately follows the declaration.
