### PR TITLE
Fixed mixed content issue and added comments support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,23 +65,38 @@ Yields:
                     children:
                      [ { name: 'id',
                          attributes: {},
-                         children: [],
-                         content: '003D000000OY9omIAD' },
-                       { name: 'success', attributes: {}, children: [], content: 'true' } ],
-                    content: '' },
+                         children: [{name: '#text', content: '003D000000OY9omIAD'}]
+                       { name: 'success', attributes: {}, children: [{name: '#text', content: 'true'}] } ],
+                  },
                   { name: 'result',
                     attributes: {},
                     children:
                      [ { name: 'id',
                          attributes: {},
-                         children: [],
-                         content: '001D000000HTK3aIAH' },
-                       { name: 'success', attributes: {}, children: [], content: 'true' } ],
-                    content: '' } ],
-               content: '' } ],
-          content: '' } ],
-     content: '' } }
+                         children: [{name: '#text', content: '001D000000HTK3aIAH'}]
+                       { name: 'success', attributes: {}, children: [{name: '#text', content: 'true'}] } ],
+                  } ],
+                } ],
+          } ],
+     } }
 ```
+
+## Options
+
+ JavaScript:
+ 
+```js
+var inspect = require('util').inspect;
+var parse = require('xml-parser');
+var options = {trim: false, stripComments: false};
+
+var obj = parse(xml, options);
+console.log(inspect(obj, { colors: true, depth: Infinity }));
+```
+
+- `trim` (Boolean, default=true) Set to true to trim the input before parsing it.
+- `stripComments` (Boolean, default=true) Set to true to strip the comments when parsing.
+
 
 # License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xml-parser",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "repository": "segmentio/xml-parser",
   "description": "the little xml parser that could",
   "scripts": {


### PR DESCRIPTION
This relates to two issues raised:
- https://github.com/segmentio/xml-parser/issues/21
- https://github.com/segmentio/xml-parser/issues/19

I've bumped up the version to `2.0.0` as there is a major change with the output object, the text content is no longer added as the `content` attribute but a child of the node so instead it's added inside the list of the `children` attribute.